### PR TITLE
Simplify Dashboard layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,11 @@ const App = () => (
                 <NewPost />
               </ProtectedRoute>
             } />
+            <Route path="/create" element={
+              <ProtectedRoute>
+                <NewPost />
+              </ProtectedRoute>
+            } />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </BrowserRouter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,6 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/contexts/AuthContext";
 import ProtectedRoute from "@/components/ProtectedRoute";
 import Index from "./pages/Index";
-import Home from "./pages/Home";
 import Dashboard from "./pages/Dashboard";
 import NewPost from "./pages/NewPost";
 import NotFound from "./pages/NotFound";
@@ -23,11 +22,6 @@ const App = () => (
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Index />} />
-            <Route path="/home" element={
-              <ProtectedRoute>
-                <Home />
-              </ProtectedRoute>
-            } />
             <Route path="/dashboard" element={
               <ProtectedRoute>
                 <Dashboard />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { AuthProvider } from "@/contexts/AuthContext";
 import ProtectedRoute from "@/components/ProtectedRoute";
 import Index from "./pages/Index";
 import Dashboard from "./pages/Dashboard";
+// import Home from "./pages/Home"; // temporarily disabled
 import NewPost from "./pages/NewPost";
 import NotFound from "./pages/NotFound";
 
@@ -22,6 +23,13 @@ const App = () => (
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Index />} />
+            {/*
+            <Route path="/home" element={
+              <ProtectedRoute>
+                <Home />
+              </ProtectedRoute>
+            } />
+            */}
             <Route path="/dashboard" element={
               <ProtectedRoute>
                 <Dashboard />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -9,10 +9,10 @@ const Hero = () => {
   const { user, loading, signInWithGoogle } = useAuth();
   const navigate = useNavigate();
 
-  // Redirect to home if user is already logged in
+  // Redirect to dashboard if user is already logged in
   useEffect(() => {
     if (!loading && user) {
-      navigate('/home');
+      navigate('/dashboard');
     }
   }, [user, loading, navigate]);
 
@@ -26,7 +26,7 @@ const Hero = () => {
 
   const handleLoginClick = () => {
     if (user) {
-      navigate('/home');
+      navigate('/dashboard');
     } else {
       handleGoogleLogin();
     }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -12,6 +12,7 @@ const Hero = () => {
   // Redirect to dashboard if user is already logged in
   useEffect(() => {
     if (!loading && user) {
+      // navigate('/home');
       navigate('/dashboard');
     }
   }, [user, loading, navigate]);
@@ -26,6 +27,7 @@ const Hero = () => {
 
   const handleLoginClick = () => {
     if (user) {
+      // navigate('/home');
       navigate('/dashboard');
     } else {
       handleGoogleLogin();

--- a/src/components/dashboard/CreatePostCard.tsx
+++ b/src/components/dashboard/CreatePostCard.tsx
@@ -1,0 +1,20 @@
+import { Plus } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { Card, CardContent } from "@/components/ui/card";
+
+const CreatePostCard = () => {
+  const navigate = useNavigate();
+  return (
+    <Card
+      onClick={() => navigate('/create')}
+      className="cursor-pointer bg-gray-800/50 border-gray-700 hover:border-[#00BFA6] rounded-3xl h-40 flex items-center justify-center"
+    >
+      <CardContent className="flex items-center gap-3">
+        <Plus className="w-6 h-6 text-[#00BFA6]" />
+        <span className="text-xl text-white font-medium">Start Creating</span>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CreatePostCard;

--- a/src/components/dashboard/PostHistory.tsx
+++ b/src/components/dashboard/PostHistory.tsx
@@ -1,0 +1,116 @@
+import { useAuth } from "@/contexts/AuthContext";
+import { supabase } from "@/integrations/supabase/client";
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Edit2, Trash, Copy } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+interface Post {
+  id: string;
+  title: string;
+  content: string | null;
+  created_at: string | null;
+}
+
+const PostHistory = () => {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      if (!user) return;
+      const { data, error } = await supabase
+        .from('posts')
+        .select('id,title,content,created_at')
+        .eq('user_id', user.id)
+        .order('created_at', { ascending: false })
+        .limit(3);
+      if (!error && data) setPosts(data);
+      setLoading(false);
+    };
+    fetchPosts();
+  }, [user]);
+
+  const formatDate = (date: string | null) =>
+    date ? new Date(date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : '';
+
+  const truncate = (text: string, len = 60) =>
+    text.length <= len ? text : text.slice(0, len) + '...';
+
+  const handleCopy = (content: string | null) => {
+    if (content) navigator.clipboard.writeText(content);
+  };
+
+  if (loading) {
+    return (
+      <Card className="bg-gray-800/50 border-gray-700 rounded-3xl">
+        <CardHeader>
+          <CardTitle className="text-white text-lg">Recent Posts</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-gray-300">Loading...</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="bg-gray-800/50 border-gray-700 rounded-3xl">
+      <CardHeader className="flex justify-between items-center">
+        <CardTitle className="text-white text-lg">Recent Posts</CardTitle>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => navigate('/posts')}
+          className="text-[#00BFA6] hover:text-[#00d7be]"
+        >
+          View All
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {posts.length === 0 ? (
+          <p className="text-gray-300">No posts yet.</p>
+        ) : (
+          <div className="space-y-3">
+            {posts.map((post) => (
+              <div
+                key={post.id}
+                className="bg-gray-700/30 rounded-lg p-3 flex justify-between items-start"
+              >
+                <div>
+                  <h4 className="text-white font-medium">
+                    {truncate(post.title || 'Untitled')}
+                  </h4>
+                  <div className="text-xs text-gray-400">
+                    {formatDate(post.created_at)} · Published
+                  </div>
+                </div>
+                <div className="flex gap-1">
+                  <Button size="icon" variant="ghost" className="text-gray-300 hover:text-white">
+                    <Edit2 className="w-4 h-4" />
+                  </Button>
+                  <Button size="icon" variant="ghost" className="text-gray-300 hover:text-red-500">
+                    <Trash className="w-4 h-4" />
+                  </Button>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="text-gray-300 hover:text-white"
+                    onClick={() => handleCopy(post.content)}
+                  >
+                    <Copy className="w-4 h-4" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default PostHistory;

--- a/src/components/dashboard/ProfileCard.tsx
+++ b/src/components/dashboard/ProfileCard.tsx
@@ -1,0 +1,76 @@
+import { useAuth } from "@/contexts/AuthContext";
+import { supabase } from "@/integrations/supabase/client";
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { CheckCircle, AlertCircle } from "lucide-react";
+
+interface ProfileData {
+  linkedin_connected: boolean | null;
+  subscription_plan: string | null;
+  posts_this_month: number | null;
+}
+
+const ProfileCard = () => {
+  const { user } = useAuth();
+  const [data, setData] = useState<ProfileData>({
+    linkedin_connected: null,
+    subscription_plan: null,
+    posts_this_month: null
+  });
+
+  useEffect(() => {
+    const load = async () => {
+      if (!user) return;
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('linkedin_connected, subscription_plan, posts_this_month')
+        .eq('id', user.id)
+        .single();
+      if (!error && data) setData(data);
+    };
+    load();
+  }, [user]);
+
+  const plan = data.subscription_plan || 'Free';
+
+  return (
+    <Card className="bg-gray-800/50 border-gray-700 rounded-3xl">
+      <CardHeader>
+        <CardTitle className="text-white text-lg">Profile</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center gap-3">
+          <Avatar className="w-12 h-12">
+            <AvatarImage src={user?.user_metadata?.avatar_url || ''} alt={user?.user_metadata?.full_name || 'User'} />
+            <AvatarFallback className="bg-[#00BFA6] text-white">
+              {user?.user_metadata?.full_name?.[0] || 'U'}
+            </AvatarFallback>
+          </Avatar>
+          <div>
+            <div className="text-white font-medium">{user?.user_metadata?.full_name || 'User'}</div>
+            <div className="text-gray-400 text-sm">{user?.email}</div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          {data.linkedin_connected ? (
+            <CheckCircle className="text-[#00BFA6] w-4 h-4" />
+          ) : (
+            <AlertCircle className="text-amber-400 w-4 h-4" />
+          )}
+          <span className="text-gray-300">
+            LinkedIn {data.linkedin_connected ? 'Connected' : 'Not Connected'}
+          </span>
+        </div>
+        <div className="text-gray-300 text-sm">{plan} Plan</div>
+        {data.posts_this_month !== null && (
+          <div className="text-xs text-gray-400">
+            You've created {data.posts_this_month} posts this month
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ProfileCard;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -52,7 +52,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: `${window.location.origin}/home`
+        redirectTo: `${window.location.origin}/dashboard`
       }
     });
     

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -52,6 +52,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
+        // redirectTo: `${window.location.origin}/home`,
         redirectTo: `${window.location.origin}/dashboard`
       }
     });

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,11 +4,10 @@ import { useNavigate } from "react-router-dom";
 import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { LogOut } from "lucide-react";
-import DashboardStats from "@/components/DashboardStats";
-import QuickActions from "@/components/QuickActions";
-import RecentPosts from "@/components/RecentPosts";
 import DailyTip from "@/components/DailyTip";
-import ProfileStatus from "@/components/ProfileStatus";
+import CreatePostCard from "@/components/dashboard/CreatePostCard";
+import PostHistory from "@/components/dashboard/PostHistory";
+import ProfileCard from "@/components/dashboard/ProfileCard";
 
 const Dashboard = () => {
   const { user, signOut, loading } = useAuth();
@@ -40,14 +39,6 @@ const Dashboard = () => {
   if (!user) {
     return null;
   }
-
-  // Mock data - in a real app, this would come from API/database
-  const dashboardData = {
-    postsThisMonth: 8,
-    engagementRate: 4.2,
-    totalViews: 12500,
-    scheduledPosts: 3
-  };
 
   return (
     <div className="min-h-screen bg-[#1A1A1A] text-[#E0E0E0]">
@@ -84,20 +75,13 @@ const Dashboard = () => {
             </p>
           </div>
 
-          {/* Stats Overview */}
-          <DashboardStats {...dashboardData} />
-
-          {/* Main Content Grid */}
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-            {/* Left Column - Main Content */}
-            <div className="lg:col-span-2 space-y-6">
-              <QuickActions />
-              <RecentPosts />
-            </div>
-
-            {/* Right Column - Sidebar */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
             <div className="space-y-6">
-              <ProfileStatus />
+              <CreatePostCard />
+              <PostHistory />
+            </div>
+            <div className="space-y-6">
+              <ProfileCard />
               <DailyTip />
             </div>
           </div>

--- a/src/pages/NewPost.tsx
+++ b/src/pages/NewPost.tsx
@@ -27,7 +27,7 @@ const NewPost = () => {
   const isProfileIncomplete = true;
 
   const handleBack = () => {
-    navigate('/home');
+    navigate('/dashboard');
   };
 
   const handleGenerate = async () => {

--- a/src/pages/NewPost.tsx
+++ b/src/pages/NewPost.tsx
@@ -27,6 +27,7 @@ const NewPost = () => {
   const isProfileIncomplete = true;
 
   const handleBack = () => {
+    // navigate('/home');
     navigate('/dashboard');
   };
 


### PR DESCRIPTION
## Summary
- add minimal dashboard components: profile card, create post card, and recent post history
- simplify dashboard layout to use new components
- add `/create` route for new post page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686622469a40832d98e714ac87711862